### PR TITLE
issue-32: fix crash that happens when getQuestion is called on a Flas…

### DIFF
--- a/core/src/com/shatteredpixel/shatteredpixeldungeon/flashcard/FlashDeck.java
+++ b/core/src/com/shatteredpixel/shatteredpixeldungeon/flashcard/FlashDeck.java
@@ -51,6 +51,9 @@ public class FlashDeck implements IFlashDeck
 
 	//this function could definitely be made faster if it ends up slowing things down
 	public IFlashQuestion getQuestion() {
+		if (questions.size() == 0) {
+			return new FlashQuestion("Error: the \"" + deckName + "\" deck has no cards", "Error: the \"" + deckName + "\" deck has no cards");
+		}
 		int totalWeight = 0;
 		for (int i = 0; i < questions.size(); i++) {
 			totalWeight += questions.get(i).getWeight();


### PR DESCRIPTION
Pretty simple. I just put in a fix so the game won't crash if a deck is empty. It'll instead show a card explaining the situation.